### PR TITLE
Temporarily disable Firebase deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -99,7 +99,7 @@ jobs:
   deploy-frontend:
     needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: false  # Temporarily disabled - requires FIREBASE_SERVICE_ACCOUNT secret
     
     steps:
     - name: Checkout code

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -50,7 +50,7 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: false  # Temporarily disabled - requires FIREBASE_SERVICE_ACCOUNT secret
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Disable Firebase deployment in CI/CD pipeline due to missing FIREBASE_SERVICE_ACCOUNT secret
- Frontend tests and build still working correctly
- Backend deployment to Render remains active
- Firebase deployment can be re-enabled once secrets are configured in GitHub